### PR TITLE
Use alpine images for studio/Dockerfile

### DIFF
--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -7,24 +7,38 @@
 #    docker builder prune
 
 
-FROM node:14-slim as builder
-WORKDIR /app
 # Do `npm ci` separately so we can cache `node_modules`
 # https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
-COPY package*.json ./
+FROM node:14-alpine AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json ./ 
 RUN npm clean-install && npm cache clean --force
+
+FROM node:14-alpine as builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN NEXT_STANDALONE=true npm run build
+# NODE_OPTIONS because of OOM on low specs docker-host (1G RAM, 4G Swap) -> https://github.com/vercel/next.js/issues/32314#issuecomment-1046274967
+RUN NEXT_STANDALONE=true \
+    NODE_OPTIONS=--max_old_space_size=8192 \
+    npm run build
 
 # This leverages Next.js output file tracing to reduce image size:
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-FROM node:14-slim as production
+FROM node:14-alpine as production
 WORKDIR /app
+ENV NODE_ENV production
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
 COPY --from=builder /app/next.config.js ./
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
 
 EXPOSE 3000
+
 CMD ["node", "server.js"]


### PR DESCRIPTION
I looked at the vercel/next.js sample Dockerfile and thought this could be included.
Most of the code is from [vercel/next.js](https://github.com/vercel/next.js/blob/99ee2225c17a8ff8f68826d229230601b2a6edc6/examples/with-docker/Dockerfile)